### PR TITLE
Use Ember.isEqual instead of direct equality

### DIFF
--- a/addon/change-gate.js
+++ b/addon/change-gate.js
@@ -17,7 +17,7 @@ export default function(dependentKey, filter) {
         let newValue = filter.call(this, get(this, dependentKey));
         let lastValue = this[lastValueKey];
 
-        if(newValue !== lastValue) {
+        if(!Em.isEqual(newValue, lastValue)) {
           this[lastValueKey] = newValue;
           this.notifyPropertyChange(key);
         }


### PR DESCRIPTION
`Ember.isEqual` lets us define our own equality functions, is there any chance we can use that instead of `!==`?